### PR TITLE
Add interactive gosling conversations and pagination support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,18 +81,25 @@ The server provides the following tools:
 
 1. `run_goose`: Runs a Goose command with the specified prompt.
 2. `list_goslings`: Lists all running and completed Goose processes.
-3. `get_gosling_output`: Gets the current output from a specific gosling process.
-4. `terminate_gosling`: Terminates a specific gosling process.
+3. `get_gosling_output`: Gets the current output from a specific gosling process with pagination support.
+4. `send_prompt_to_gosling`: Sends a follow-up prompt to a running gosling process, enabling interactive conversations.
+5. `release_gosling`: Releases a specific gosling process when you're done with it.
 
 ## Key Implementation Details
 
 1. **Process Management**: Uses Node.js's `child_process` module to spawn and manage Goose processes, collecting their output and providing it through MCP tools and resources.
 
-2. **Error Handling**: Comprehensive error handling for process failures, missing Goose installation, and invalid requests.
+2. **Interactive Goslings**: Supports sending follow-up prompts to running gosling processes, enabling multi-turn conversations and iterative workflows.
 
-3. **MCP SDK Integration**: Implements the Model Context Protocol using the `@modelcontextprotocol/sdk` package.
+3. **Pagination Support**: Provides Unix-like pagination (similar to `more`/`less`) for viewing large outputs efficiently, with options for jumping to specific sections or viewing the full output.
 
-4. **Environment Variables**: Sets up non-ANSI terminal environment variables to ensure proper output formatting.
+4. **Prompt History**: Tracks the history of all prompts sent to each gosling process, making it easy to see the conversation flow.
+
+5. **Error Handling**: Comprehensive error handling for process failures, missing Goose installation, and invalid requests.
+
+6. **MCP SDK Integration**: Implements the Model Context Protocol using the `@modelcontextprotocol/sdk` package.
+
+7. **Environment Variables**: Sets up non-ANSI terminal environment variables to ensure proper output formatting.
 
 ## Codebase Tips
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Mother Goose allows AI agents (like Claude in Anthropic Console) to:
 
 1. **Spawn child AI instances** using Goose CLI
 2. **Manage multiple "goslings" in parallel** for collaborative problem-solving
-3. **Monitor subprocess status and output** in real-time
-4. **Release child processes** when they're no longer needed
+3. **Monitor subprocess status and output** in real-time, with pagination for large outputs
+4. **Have interactive conversations** with running gosling processes via follow-up prompts
+5. **Release child processes** when they're no longer needed
 
-This creates a powerful recursive capability where an AI can delegate subtasks to other AI instances, enabling more complex workflows and reasoning chains.
+This creates a powerful recursive capability where an AI can delegate subtasks to other AI instances and have ongoing conversations with them, enabling more complex workflows and interactive reasoning chains.
 
 ## Documentation
 
@@ -81,14 +82,30 @@ Use the list_goslings tool to see all active processes.
 
 ### 3. `get_gosling_output`
 
-Gets the current output from a specific gosling process.
+Gets the current output from a specific gosling process with pagination support.
 
 **Example:**
 ```
+# Basic usage
 Use the get_gosling_output tool to check the results from process [ID].
+
+# With pagination (Unix more/less style)
+Use the get_gosling_output tool with offset=100 and limit=50 to view lines 100-150.
+
+# Get full output
+Use the get_gosling_output tool with full_output=true to get the complete output.
 ```
 
-### 4. `release_gosling`
+### 4. `send_prompt_to_gosling`
+
+Sends a follow-up prompt to a running gosling process in interactive mode, enabling multi-turn conversations. Goslings are automatically started in interactive mode, so they stay alive and can receive multiple prompts.
+
+**Example:**
+```
+Use the send_prompt_to_gosling tool to ask the gosling at process [ID] to elaborate on its findings.
+```
+
+### 5. `release_gosling`
 
 Releases a specific gosling process when you're done with it.
 
@@ -110,6 +127,27 @@ I need to solve a complex machine learning problem. Use the run_goose tool to cr
 3. One to draft code snippets for implementation
 
 Then, I'll coordinate their efforts to produce a comprehensive solution.
+```
+
+### Interactive Conversations with Goslings
+
+You can have multi-turn conversations with running goslings, providing feedback or additional instructions:
+
+```
+# Create a gosling to work on a task
+Use the run_goose tool to create a gosling for drafting a research proposal.
+
+# Check initial progress
+Use the get_gosling_output tool to see the gosling's progress.
+
+# Send follow-up instructions
+Use the send_prompt_to_gosling tool to refine the focus: "Please emphasize the methodology section and expand on the data collection approach."
+
+# Check updated output
+Use the get_gosling_output tool to see how the gosling incorporated your feedback.
+
+# Continue the conversation
+Use the send_prompt_to_gosling tool again: "Now please add a budget section with estimated costs."
 ```
 
 ### Advanced: Shared Memory Coordination

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -4,12 +4,13 @@ This document provides detailed reference information for all MCP tools provided
 
 ## Overview
 
-Mother Goose provides four main tools that enable AI agents to interact with Goose CLI:
+Mother Goose provides five main tools that enable AI agents to interact with Goose CLI:
 
 1. `run_goose`: Create and start a new Goose process
 2. `list_goslings`: List all Goose processes
-3. `get_gosling_output`: Get output from a specific process
-4. `release_gosling`: Release a specific process
+3. `get_gosling_output`: Get output from a specific process with pagination support
+4. `send_prompt_to_gosling`: Send a follow-up prompt to a running gosling process
+5. `release_gosling`: Release a specific process
 
 ## Tool Details
 
@@ -81,20 +82,25 @@ Lists all running and completed Goose processes.
 
 ### `get_gosling_output`
 
-Gets the current output from a specific gosling process.
+Gets the current output from a specific gosling process with pagination support for handling large outputs.
 
 **Parameters:**
 - `process_id` (string, required): ID of the gosling process
+- `offset` (number, optional): Line number to start from (0-indexed). Defaults to 0.
+- `limit` (number, optional): Maximum number of lines to return. Defaults to 100.
+- `full_output` (boolean, optional): Return complete output regardless of size. Defaults to false.
 
 **Returns:**
-- Process details and current output
+- Process details, prompt history, and paginated output
 
 **Example Request:**
 ```json
 {
   "name": "get_gosling_output",
   "arguments": {
-    "process_id": "123e4567-e89b-12d3-a456-426614174000"
+    "process_id": "123e4567-e89b-12d3-a456-426614174000",
+    "offset": 0,
+    "limit": 50
   }
 }
 ```
@@ -105,7 +111,41 @@ Gets the current output from a specific gosling process.
   "content": [
     {
       "type": "text",
-      "text": "=== Gosling Process 123e4567-e89b-12d3-a456-426614174000 ===\nStatus: running\nStarted: 2023-06-15 14:22:45\nDuration: 1m 15s (running)\nPrompt: \"Explain quantum computing in simple terms\"\n\nQuantum computing is a type of computing that uses quantum mechanics to process information. Unlike regular computers that use bits (0s and 1s), quantum computers use quantum bits or 'qubits' which can exist in multiple states at once. This allows quantum computers to solve certain problems much faster than traditional computers.\n\nImagine a regular computer as having to check every path in a maze one at a time, while a quantum computer can check many paths simultaneously. This makes quantum computers potentially very powerful for specific tasks like breaking certain types of encryption, simulating molecules for drug discovery, or optimizing complex systems."
+      "text": "=== Gosling Process 123e4567-e89b-12d3-a456-426614174000 ===\nStatus: running\nStarted: 2023-06-15 14:22:45\nDuration: 1m 15s (running)\nPrompts: 2\n  1. [2023-06-15 14:22:45] \"Explain quantum computing in simple terms\"\n  2. [2023-06-15 14:24:10] \"How does quantum entanglement work?\"\n\n=== Output (1-50 of 150 lines) ===\n\nQuantum computing is a type of computing that uses quantum mechanics to process information. Unlike regular computers that use bits (0s and 1s), quantum computers use quantum bits or 'qubits' which can exist in multiple states at once. This allows quantum computers to solve certain problems much faster than traditional computers.\n\nImagine a regular computer as having to check every path in a maze one at a time, while a quantum computer can check many paths simultaneously. This makes quantum computers potentially very powerful for specific tasks like breaking certain types of encryption, simulating molecules for drug discovery, or optimizing complex systems.\n\n=== Pagination ===\nShowing lines 1 to 50 of 150 total lines.\nTo see more, use:\n  - Next page: offset=50 limit=50\n  - Full output: full_output=true"
+    }
+  ]
+}
+```
+
+### `send_prompt_to_gosling`
+
+Sends a follow-up prompt to a running gosling process, enabling interactive multi-turn conversations.
+
+**Parameters:**
+- `process_id` (string, required): ID of the gosling process
+- `prompt` (string, required): The follow-up prompt to send to the gosling
+
+**Returns:**
+- Confirmation message
+
+**Example Request:**
+```json
+{
+  "name": "send_prompt_to_gosling",
+  "arguments": {
+    "process_id": "123e4567-e89b-12d3-a456-426614174000",
+    "prompt": "How does quantum entanglement work?"
+  }
+}
+```
+
+**Example Response:**
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "Successfully sent follow-up prompt to gosling 123e4567-e89b-12d3-a456-426614174000\n\nPrompt #2: \"How does quantum entanglement work?\"\n\nThe gosling is processing your follow-up prompt. You can check its progress using:\n- get_gosling_output tool with process_id=\"123e4567-e89b-12d3-a456-426614174000\"\n- Resource URI: goslings://123e4567-e89b-12d3-a456-426614174000/output\n\nThis allows for interactive, multi-turn conversations with your gosling process."
     }
   ]
 }
@@ -154,6 +194,10 @@ Releases a specific gosling process when you're done with it.
 4. **Handle Errors Gracefully**: Check for error messages in the output and handle them appropriately.
 
 5. **Use Options Judiciously**: The `options` parameter in `run_goose` can provide more control, but be aware of compatibility with different Goose CLI versions.
+
+6. **Interactive Conversations**: Use `send_prompt_to_gosling` to have multi-turn conversations with running goslings, allowing for clarification, refinement, and follow-up questions.
+
+7. **Paginate Large Outputs**: For goslings with large outputs, use pagination parameters in `get_gosling_output` to view specific sections without overwhelming your context.
 
 ## See Also
 

--- a/docs/usage/advanced-usage.md
+++ b/docs/usage/advanced-usage.md
@@ -81,6 +81,51 @@ Use the run_goose tool to analyze this large dataset...
 Use the get_gosling_output tool to check if process XYZ has completed its analysis.
 ```
 
+## Interactive Conversations with Goslings
+
+Mother Goose now supports multi-turn conversations with goslings, allowing for interactive workflows:
+
+### Sending Follow-Up Prompts
+
+After starting a gosling, you can send additional prompts to it:
+
+```
+# Step 1: Start a gosling
+Use the run_goose tool with prompt="What are the fundamental principles of machine learning?"
+
+# Step 2: Wait for initial response
+Use the get_gosling_output tool with process_id="..." to see the initial response
+
+# Step 3: Send a follow-up question
+Use the send_prompt_to_gosling tool with process_id="..." and prompt="Can you elaborate on neural networks?"
+
+# Step 4: Get updated response
+Use the get_gosling_output tool again to see the combined conversation
+```
+
+### Session Persistence
+
+Gosling sessions are automatically managed with the following features:
+
+1. All goslings run in interactive mode with named sessions
+2. If a gosling has exited, it can be automatically resumed when sending a follow-up prompt
+3. Full prompt history is maintained and displayed in the output
+
+### Paginated Output Viewing
+
+For goslings generating large amounts of output, you can use pagination:
+
+```
+# View first 100 lines (default)
+Use the get_gosling_output tool with process_id="..."
+
+# View specific section (lines 200-300)
+Use the get_gosling_output tool with process_id="...", offset=200, limit=100
+
+# View entire output
+Use the get_gosling_output tool with process_id="...", full_output=true
+```
+
 ## Error Handling
 
 Sometimes goslings may encounter errors. You can:

--- a/src/gosling-manager.ts
+++ b/src/gosling-manager.ts
@@ -3,6 +3,15 @@
  */
 import { spawn, ChildProcess } from "child_process";
 import { randomUUID } from "crypto";
+import { formatDuration } from "./utils.js";
+
+/**
+ * Interface for prompt history entry
+ */
+export interface PromptEntry {
+  prompt: string;
+  timestamp: Date;
+}
 
 /**
  * Interface for a Gosling process
@@ -17,6 +26,9 @@ export interface Gosling {
   error: string;
   startTime: Date;
   endTime?: Date;
+  promptHistory: PromptEntry[];
+  outputLineCount: number;
+  sessionName: string;  // Name of the Goose session
 }
 
 /**
@@ -31,16 +43,23 @@ export class GoslingManager {
   async runGoose(prompt: string, options: string[] = []): Promise<Gosling> {
     const id = randomUUID();
     
-    // Build the command arguments
-    const args = ["run"];
-    
+    // Generate a unique session name for this gosling
+    const sessionName = `gosling-${id.substring(0, 8)}`;
+
+    // Build the command arguments with interactive mode and named session
+    // -s: Interactive mode, stays open for further input
+    // -n: Named session for later resumption
+    const args = ["run", "-s", "-n", sessionName];
+
     // Add any options (like -t for text-only mode)
     if (options && options.length > 0) {
       args.push(...options);
     }
-    
-    // Add the --text option and prompt
-    args.push("--text", prompt);
+
+    // Add the --text option with a modified prompt to encourage interactivity
+    // This helps the model understand it's expected to stay active and responsive
+    const interactivePrompt = `I'll be sending you multiple prompts in this session. Please respond to each one as they come.\n\nYour first task: ${prompt}`;
+    args.push("--text", interactivePrompt);
     
     console.error(`Starting Goose process: goose ${args.join(" ")}`);
     
@@ -67,15 +86,19 @@ export class GoslingManager {
     const gooseProcess = spawn("goose", args, { env });
     
     // Create a new Gosling object
+    const timestamp = new Date();
     const gosling: Gosling = {
       id,
-      prompt,
+      prompt,  // Store the original user prompt, not our modified one
       options,
       process: gooseProcess,
       status: "running",
       output: "",
       error: "",
-      startTime: new Date()
+      startTime: timestamp,
+      promptHistory: [{ prompt, timestamp }],  // Original prompt in history
+      outputLineCount: 0,
+      sessionName
     };
     
     // Store the Gosling
@@ -83,7 +106,12 @@ export class GoslingManager {
     
     // Collect stdout
     gooseProcess.stdout.on("data", (data) => {
-      gosling.output += data.toString();
+      const text = data.toString();
+      gosling.output += text;
+
+      // Count new lines
+      const newLines = text.split('\n').length - 1;
+      gosling.outputLineCount += newLines;
     });
     
     // Collect stderr
@@ -123,6 +151,165 @@ export class GoslingManager {
   }
   
   /**
+   * Send a follow-up prompt to a Gosling process
+   * If the process has completed, it will attempt to resume the session
+   */
+  async sendPromptToGosling(id: string, followUpPrompt: string): Promise<boolean> {
+    const gosling = this.goslings.get(id);
+    if (!gosling) {
+      return false;
+    }
+
+    // If the process is not running, try to resume the session
+    if (gosling.status !== "running") {
+      try {
+        console.error(`Gosling ${id} is not running (status: ${gosling.status}). Attempting to resume session ${gosling.sessionName}...`);
+
+        // Build command to resume the session
+        // Note: We need to provide both the session name AND a text prompt
+        // Even for resumed sessions, Goose requires a text prompt
+        const resumeArgs = ["run", "-s", "-n", gosling.sessionName, "-r", "--text", followUpPrompt];
+
+        // Get the parent's environment variables
+        const env = {
+          ...process.env,
+          DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1000/bus",
+          // Disable ANSI color output
+          TERM: "dumb",
+          NO_COLOR: "1",
+          CLICOLOR: "0",
+          FORCE_COLOR: "0"
+        };
+
+        // Spawn a new process to resume the session
+        const newProcess = spawn("goose", resumeArgs, { env });
+
+        // Update the gosling object
+        gosling.process = newProcess;
+        gosling.status = "running";
+        if (gosling.endTime) {
+          console.error(`Gosling ${id} was inactive for ${formatDuration(gosling.endTime, new Date())}`);
+        }
+        gosling.endTime = undefined;
+
+        // Set up event handlers for the new process
+        newProcess.stdout.on("data", (data) => {
+          const text = data.toString();
+          gosling.output += text;
+          // Count new lines
+          const newLines = text.split('\n').length - 1;
+          gosling.outputLineCount += newLines;
+        });
+
+        newProcess.stderr.on("data", (data) => {
+          gosling.error += data.toString();
+        });
+
+        newProcess.on("exit", (code) => {
+          gosling.endTime = new Date();
+          gosling.status = code === 0 ? "completed" : "error";
+          console.error(`Goose process ${id} exited with code ${code}`);
+        });
+
+        newProcess.on("error", (err) => {
+          gosling.error += err.message;
+          gosling.status = "error";
+          console.error(`Goose process ${id} error: ${err.message}`);
+        });
+
+        // Give the process a moment to start up
+        await new Promise(resolve => setTimeout(resolve, 500));
+      } catch (error) {
+        console.error(`Failed to resume gosling ${id} session: ${error instanceof Error ? error.message : String(error)}`);
+        return false;
+      }
+    }
+
+    // Check if the process's stdin is writable
+    if (!gosling.process.stdin || !gosling.process.stdin.writable) {
+      console.error(`Gosling ${id} stdin is not writable`);
+      return false;
+    }
+
+    try {
+      // Log the follow-up prompt
+      console.error(`Sending follow-up prompt to gosling ${id} (session ${gosling.sessionName}): "${followUpPrompt.substring(0, 30)}${followUpPrompt.length > 30 ? '...' : ''}"`);
+
+      // Format the prompt with a clear separator, context reminder, and newlines
+      const formattedPrompt = `\n\n--- NEW QUESTION/INSTRUCTION ---\n${followUpPrompt}\n\nPlease respond to this new question/instruction.\n\n`;
+
+      // Write the prompt to the gosling's stdin and ensure it's sent
+      gosling.process.stdin.write(formattedPrompt);
+
+      // Add to prompt history
+      const timestamp = new Date();
+      gosling.promptHistory.push({ prompt: followUpPrompt, timestamp });
+
+      return true;
+    } catch (error) {
+      console.error(`Error sending prompt to gosling ${id}: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+  }
+
+  /**
+   * Get paginated output from a Gosling
+   */
+  getGoslingOutput(id: string, offset: number = 0, limit: number = 100, fullOutput: boolean = false): {
+    text: string;
+    metadata: {
+      totalLines: number;
+      startLine: number;
+      endLine: number;
+      hasMore: boolean;
+    };
+  } | undefined {
+    const gosling = this.goslings.get(id);
+    if (!gosling) {
+      return undefined;
+    }
+
+    // If full output is requested, return everything
+    if (fullOutput) {
+      return {
+        text: gosling.output,
+        metadata: {
+          totalLines: gosling.outputLineCount,
+          startLine: 0,
+          endLine: gosling.outputLineCount,
+          hasMore: false
+        }
+      };
+    }
+
+    // Split output into lines
+    const lines = gosling.output.split('\n');
+
+    // Validate offset
+    if (offset < 0) offset = 0;
+    if (offset >= lines.length) offset = Math.max(0, lines.length - 1);
+
+    // Validate limit
+    if (limit <= 0) limit = 100;
+
+    // Calculate end index (exclusive)
+    const endIndex = Math.min(offset + limit, lines.length);
+
+    // Get requested lines
+    const requestedLines = lines.slice(offset, endIndex);
+
+    return {
+      text: requestedLines.join('\n'),
+      metadata: {
+        totalLines: lines.length,
+        startLine: offset,
+        endLine: endIndex,
+        hasMore: endIndex < lines.length
+      }
+    };
+  }
+
+  /**
    * Terminate a Gosling process
    */
   terminateGosling(id: string): boolean {
@@ -130,13 +317,13 @@ export class GoslingManager {
     if (!gosling) {
       return false;
     }
-    
+
     if (gosling.status === "running") {
       gosling.process.kill();
       gosling.status = "completed";
       gosling.endTime = new Date();
     }
-    
+
     return true;
   }
 }

--- a/tests/gosling-manager.test.ts
+++ b/tests/gosling-manager.test.ts
@@ -12,6 +12,10 @@ jest.mock('child_process', () => {
       const mockProcess = new EventEmitter() as ChildProcess;
       mockProcess.stdout = new EventEmitter();
       mockProcess.stderr = new EventEmitter();
+      mockProcess.stdin = {
+        write: jest.fn(() => true),
+        writable: true
+      };
       mockProcess.kill = jest.fn();
       return mockProcess;
     })
@@ -149,32 +153,110 @@ describe('GoslingManager', () => {
       const gosling = await manager.runGoose('Hello world');
       const { spawn } = require('child_process');
       const mockProcess = spawn();
-      
+
       const result = manager.terminateGosling('test-uuid');
-      
+
       expect(result).toBe(true);
       expect(mockProcess.kill).toHaveBeenCalled();
       expect(gosling.status).toBe('completed');
       expect(gosling.endTime).toBeInstanceOf(Date);
     });
-    
+
     it('should return false for non-existent ID', () => {
       expect(manager.terminateGosling('non-existent-id')).toBe(false);
     });
-    
+
     it('should not call kill for already completed Goslings', async () => {
       const gosling = await manager.runGoose('Hello world');
       const { spawn } = require('child_process');
       const mockProcess = spawn();
-      
+
       // Mark the gosling as completed
       gosling.status = 'completed';
       gosling.endTime = new Date();
-      
+
       const result = manager.terminateGosling('test-uuid');
-      
+
       expect(result).toBe(true);
       expect(mockProcess.kill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendPromptToGosling', () => {
+    it('should send a follow-up prompt to a running Gosling', async () => {
+      const gosling = await manager.runGoose('Hello world');
+      const { spawn } = require('child_process');
+      const mockProcess = spawn();
+
+      const result = manager.sendPromptToGosling('test-uuid', 'Follow-up prompt');
+
+      expect(result).toBe(true);
+      expect(mockProcess.stdin.write).toHaveBeenCalled();
+      expect(gosling.promptHistory.length).toBe(2);
+      expect(gosling.promptHistory[1].prompt).toBe('Follow-up prompt');
+    });
+
+    it('should return false for non-existent ID', () => {
+      expect(manager.sendPromptToGosling('non-existent-id', 'Follow-up prompt')).toBe(false);
+    });
+
+    it('should return false for non-running Goslings', async () => {
+      const gosling = await manager.runGoose('Hello world');
+
+      // Mark the gosling as completed
+      gosling.status = 'completed';
+      gosling.endTime = new Date();
+
+      const result = manager.sendPromptToGosling('test-uuid', 'Follow-up prompt');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getGoslingOutput', () => {
+    it('should return paginated output', async () => {
+      const gosling = await manager.runGoose('Hello world');
+
+      // Set up test output with multiple lines
+      gosling.output = 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5';
+      gosling.outputLineCount = 5;
+
+      // Get first 2 lines
+      const result1 = manager.getGoslingOutput('test-uuid', 0, 2);
+
+      expect(result1).toBeDefined();
+      expect(result1?.text).toBe('Line 1\nLine 2');
+      expect(result1?.metadata.totalLines).toBe(5);
+      expect(result1?.metadata.startLine).toBe(0);
+      expect(result1?.metadata.endLine).toBe(2);
+      expect(result1?.metadata.hasMore).toBe(true);
+
+      // Get next 2 lines
+      const result2 = manager.getGoslingOutput('test-uuid', 2, 2);
+
+      expect(result2).toBeDefined();
+      expect(result2?.text).toBe('Line 3\nLine 4');
+      expect(result2?.metadata.startLine).toBe(2);
+      expect(result2?.metadata.endLine).toBe(4);
+      expect(result2?.metadata.hasMore).toBe(true);
+    });
+
+    it('should return full output when requested', async () => {
+      const gosling = await manager.runGoose('Hello world');
+
+      // Set up test output with multiple lines
+      gosling.output = 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5';
+      gosling.outputLineCount = 5;
+
+      const result = manager.getGoslingOutput('test-uuid', 0, 2, true);
+
+      expect(result).toBeDefined();
+      expect(result?.text).toBe('Line 1\nLine 2\nLine 3\nLine 4\nLine 5');
+      expect(result?.metadata.hasMore).toBe(false);
+    });
+
+    it('should return undefined for non-existent ID', () => {
+      expect(manager.getGoslingOutput('non-existent-id')).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds support for interactive, multi-turn conversations with gosling processes via follow-up prompts
- Implements pagination for viewing large outputs efficiently
- Enhances gosling sessions with automatic session persistence and resumption

## Features
- New `send_prompt_to_gosling` tool for sending follow-up prompts 
- Enhanced `get_gosling_output` tool with pagination parameters
- Automatic interactive mode (-s) and named sessions (-n) for all goslings
- Session resumption for goslings that have exited
- Prompt history tracking for each gosling
- Comprehensive documentation updates

## Test plan
1. Start a new gosling with `run_goose`
2. Send a follow-up prompt with `send_prompt_to_gosling`
3. Verify the follow-up appears in the output with `get_gosling_output`
4. Test pagination with offset/limit parameters
5. Test session resumption by letting a gosling complete, then sending a new prompt